### PR TITLE
Update shader compilation to GLSL 1.50

### DIFF
--- a/panon/effect/build_shader_source.py
+++ b/panon/effect/build_shader_source.py
@@ -108,7 +108,7 @@ def build_qsb(shader_source: str) -> str:
         raise Exception("qsb not found")
     
     qsb, qsb_path = tempfile.mkstemp(dir=tmp_dir, suffix='.qsb')
-    subprocess.run([qsb_bin_path, '--qt6', frag_path, '-o', qsb_path], check=True)
+    subprocess.run([qsb_bin_path, '--glsl', '150', frag_path, '-o', qsb_path], check=True)
     os.close(qsb)
 
     return qsb_path

--- a/plasmoid/contents/shaders/gldft.fsh
+++ b/plasmoid/contents/shaders/gldft.fsh
@@ -1,7 +1,7 @@
-#version 130
+#version 440
 
-out vec4 out_Color;
-in mediump vec2 qt_TexCoord0;
+layout(location = 0) in vec2 qt_TexCoord0;
+layout(location = 0) out vec4 out_Color;
 
 uniform sampler2D waveBuffer; 
 

--- a/plasmoid/contents/shaders/wave-buffer.fsh
+++ b/plasmoid/contents/shaders/wave-buffer.fsh
@@ -1,7 +1,7 @@
-#version 130
+#version 440
 
-out vec4 out_Color;
-in mediump vec2 qt_TexCoord0;
+layout(location = 0) in vec2 qt_TexCoord0;
+layout(location = 0) out vec4 out_Color;
 
 uniform sampler2D newWave; 
 uniform sampler2D waveBuffer; 


### PR DESCRIPTION
This is a partial fix for https://github.com/flafflar/panon/issues/8

The main change is enforcing the minimum GLSL version to be 150 (the `--qt6` flag defaults to...quite a fair bit lower versions).
The motivator behind this is that it seems lots of the advanced shaders (and also as seen in the included footer/header in this repo), use `texelFetch`

Full support for this has only been added in 150: https://docs.gl/sl4/texelFetch

As no machine running Plasma6 should be limited to versions of GLSL this old, I think it is fair to apply this? Ultimately the judgement is up to you of course :)

[Also requires a slight patch to the shaders to remove `#version`](https://github.com/Doridian/panon-effects/commit/8f39f0e0b72e50cc4d2aeeca4f92ff09a1aba1ea). I wonder if this should just be automated (remove all `#version` statements from shader, add one at the top that is the highest version requested? Fail if we detect a difference?)

This does make a lot of the other shaders "just work". See one of the examples: 
![image](https://github.com/user-attachments/assets/eddb1e24-5294-4291-ba94-fc7562a132bb)
