### PR TITLE
 Use venv for panon backend to remove need to install requirements separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,29 +15,26 @@ your distro.
 
 ## Dependencies
 
+On first run, the plasmoid will create a venv and install Python dependencies automatically.
+
 ### KDE Neon
 ```sh
-sudo apt install qt6-websockets \
-    python3-docopt python3-pyaudio python3-pip
-sudo pip install --upgrade websockets
+sudo apt install qt6-websockets python3-pip python3-venv
 ```
 
 ### OpenSUSE
 ```sh
-sudo zypper in qt6-shadertools qt6-websockets-imports \ 
-    python3-docopt python3-numpy python3-PyAudio python3-websockets
+sudo zypper in qt6-shadertools qt6-websockets-imports
 ```
 
 ### Nobara
 ```sh
-sudo dnf install qt6-qtwebsockets-devel qt6-qtshadertools \
-    python3-docopt python3-numpy python3-pyaudio python3-websockets
+sudo dnf install qt6-qtwebsockets-devel qt6-qtshadertools
 ```
 
 ### Arch Linux
 ```sh
-sudo pacman -S --asdeps qt6-shadertools qt6-websockets \
-    python-websockets python-docopt python-numpy python-pyaudio
+sudo pacman -S --asdeps qt6-shadertools qt6-websockets
 ```
 You can also install the [AUR package](https://aur.archlinux.org/packages/plasma6-applets-panon)
 directly!

--- a/makepackage.sh
+++ b/makepackage.sh
@@ -12,6 +12,7 @@ rm ./plasmoid/contents/scripts/__pycache__/ -r
 rm ./plasmoid/contents/scripts/*/__pycache__/ -r
 rm ./plasmoid/contents/scripts/*/*/__pycache__/ -r
 rm ./plasmoid/contents/scripts/*/*/*/__pycache__/ -r
+rm ./plasmoid/contents/scripts/venv/ -r
 rm ./panon.plasmoid
 
 # i18n

--- a/plasmoid/contents/scripts/requirements.txt
+++ b/plasmoid/contents/scripts/requirements.txt
@@ -1,0 +1,5 @@
+docopt
+numpy
+pyaudio
+cffi
+websockets

--- a/plasmoid/contents/scripts/requirements.txt
+++ b/plasmoid/contents/scripts/requirements.txt
@@ -1,5 +1,6 @@
-docopt
-numpy
-pyaudio
-cffi
-websockets
+# IMO, supply chain attacks are more scary than old vulnerabilities.
+docopt==0.6.2
+numpy==2.4.2
+pyaudio==0.2.14
+cffi==1.17.1
+websockets==15.0.1

--- a/plasmoid/contents/ui/CreateVenv.qml
+++ b/plasmoid/contents/ui/CreateVenv.qml
@@ -5,11 +5,16 @@ import "utils.js" as Utils
  */
 PlasmaCore.DataSource {
     engine: 'executable'
+    property bool isCreated: false
     readonly property string createVenv:Utils.create_venv()
     connectedSources: [createVenv]
     onNewData:{
         // Show back-end errors.
         console.log(data.stdout)
         console.log(data.stderr)
+        if(!isCreated && data.stdout.includes('venv_created')){
+            isCreated = true
+            console.log('Venv Created!')
+        }
     }
 }

--- a/plasmoid/contents/ui/CreateVenv.qml
+++ b/plasmoid/contents/ui/CreateVenv.qml
@@ -1,0 +1,15 @@
+import org.kde.plasma.core 2.0 as PlasmaCore
+import "utils.js" as Utils
+/*
+ * Create virtual environment for auto-installing dependencies.
+ */
+PlasmaCore.DataSource {
+    engine: 'executable'
+    readonly property string createVenv:Utils.create_venv()
+    connectedSources: [createVenv]
+    onNewData:{
+        // Show back-end errors.
+        console.log(data.stdout)
+        console.log(data.stderr)
+    }
+}

--- a/plasmoid/contents/ui/CreateVenv.qml
+++ b/plasmoid/contents/ui/CreateVenv.qml
@@ -1,9 +1,9 @@
-import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.plasma5support as Plasma5Support
 import "utils.js" as Utils
 /*
  * Create virtual environment for auto-installing dependencies.
  */
-PlasmaCore.DataSource {
+Plasma5Support.DataSource {
     engine: 'executable'
     property bool isCreated: false
     readonly property string createVenv:Utils.create_venv()

--- a/plasmoid/contents/ui/ShaderSource.qml
+++ b/plasmoid/contents/ui/ShaderSource.qml
@@ -27,7 +27,7 @@ Plasma5Support.DataSource {
 
     readonly property bool enable_buffer:buffer_shader_source.length>0
 
-    readonly property string cmd:Utils.chdir_scripts_root()
+    readonly property string cmd:Utils.activate_venv()
         + 'python3 -m panon.effect.build_shader_source'
         + ' '+Qt.btoa(JSON.stringify([cfg.visualEffect,cfg.effectArgValues]))
 

--- a/plasmoid/contents/ui/Spectrum.qml
+++ b/plasmoid/contents/ui/Spectrum.qml
@@ -174,10 +174,12 @@ Item{
     readonly property bool failCompileBufferShader: loadBufferShaderSource && false // (bufferSES.sourceItem.status==ShaderEffect.Error)
     property string fps_message:""
     property string error_message:
-        shaderSourceReader.error_message
-        + (loadImageShaderSource ?"":i18n("Error: Failed to load the visual effect. Please choose another visual effect in the configuration dialog."))
-        + (failCompileImageShader?(i18n("Error: Failed to compile image shader.")+mainSE.log):"")
-        + (failCompileBufferShader?(i18n("Error: Failed to compile bufffer shader.")+bufferSES.sourceItem.log):"")
+        venvCreator.isCreated ? (
+            shaderSourceReader.error_message
+            + (loadImageShaderSource ?"":i18n("Error: Failed to load the visual effect. Please choose another visual effect in the configuration dialog."))
+            + (failCompileImageShader?(i18n("Error: Failed to compile image shader.")+mainSE.log):"")
+            + (failCompileBufferShader?(i18n("Error: Failed to compile bufffer shader.")+bufferSES.sourceItem.log):"")
+        ) : i18n("Creating Venv...")
     QQC2.Label {
         id:console_output
         anchors.fill: parent
@@ -214,6 +216,8 @@ Item{
     }
 
     ShaderSource{id:shaderSourceReader}
+
+    CreateVenv{id:venvCreator}
 
     WsConnection{
         shaderSourceReader:shaderSourceReader

--- a/plasmoid/contents/ui/WsConnection.qml
+++ b/plasmoid/contents/ui/WsConnection.qml
@@ -34,7 +34,7 @@ Item{
     readonly property string startBackEnd:{
         if(server.port==0) return '';
         if(shaderSourceReader.image_shader_source=='') return ''
-        var cmd=Utils.chdir_scripts_root()+'exec python3 -m panon.backend.client '
+        var cmd=Utils.activate_venv()+'exec python3 -m panon.backend.client '
         cmd+=server.url  //+':'+server.port
         var be=['pyaudio','soundcard','fifo'][cfg.backendIndex]
         cmd+=' --backend='+be

--- a/plasmoid/contents/ui/config/ConfigBackend.qml
+++ b/plasmoid/contents/ui/config/ConfigBackend.qml
@@ -176,8 +176,8 @@ Kirigami.FormLayout {
         }
     }
 
-    readonly property string sh_get_devices:Utils.chdir_scripts_root()+'python3 -m panon.backend.get_devices'
-    readonly property string sh_get_pa_devices:Utils.chdir_scripts_root()+'python3 -m panon.backend.get_pa_devices'
+    readonly property string sh_get_devices:Utils.activate_venv()+'python3 -m panon.backend.get_devices'
+    readonly property string sh_get_pa_devices:Utils.activate_venv()+'python3 -m panon.backend.get_pa_devices'
 
     Plasma5Support.DataSource {
         //id: getOptionsDS

--- a/plasmoid/contents/ui/config/ConfigEffect.qml
+++ b/plasmoid/contents/ui/config/ConfigEffect.qml
@@ -51,10 +51,10 @@ Kirigami.FormLayout {
     }
 
 
-    readonly property string sh_get_visual_effects:Utils.chdir_scripts_root()+'python3 -m panon.effect.get_effect_list'
+    readonly property string sh_get_visual_effects:Utils.activate_venv()+'python3 -m panon.effect.get_effect_list'
 
-    readonly property string sh_read_effect_hint:Utils.chdir_scripts_root()+'python3 -m panon.effect.read_file "'+cfg_visualEffect+'" hint.html'
-    readonly property string sh_read_effect_args:Utils.chdir_scripts_root()+'python3 -m panon.effect.read_file "'+cfg_visualEffect+'" meta.json'
+    readonly property string sh_read_effect_hint:Utils.activate_venv()+'python3 -m panon.effect.read_file "'+cfg_visualEffect+'" hint.html'
+    readonly property string sh_read_effect_args:Utils.activate_venv()+'python3 -m panon.effect.read_file "'+cfg_visualEffect+'" meta.json'
 
     onCfg_visualEffectChanged:{
         hint.text=''

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -3,6 +3,7 @@ import org.kde.plasma.plasmoid
 import org.kde.plasma.core as PlasmaCore
 
 PlasmoidItem {
+    CreateVenv{}
 
     readonly property var cfg:plasmoid.configuration
 

--- a/plasmoid/contents/ui/utils.js
+++ b/plasmoid/contents/ui/utils.js
@@ -20,7 +20,8 @@ function create_venv() {
         'test -d venv || python3 -m venv venv;' +
         '. venv/bin/activate;' +
         'pip install -r requirements.txt;' +
-        'touch venv/.created;'
+        'touch venv/.created;' +
+        'echo "venv_created"'
     )
 }
 

--- a/plasmoid/contents/ui/utils.js
+++ b/plasmoid/contents/ui/utils.js
@@ -19,12 +19,17 @@ function create_venv() {
         chdir_scripts_root() +
         'test -d venv || python3 -m venv venv;' +
         '. venv/bin/activate;' +
-        'pip install -r requirements.txt;'
+        'pip install -r requirements.txt;' +
+        'touch venv/.created;'
     )
 }
 
 function activate_venv() {
-    return chdir_scripts_root() + '. venv/bin/activate;'
+    return (
+        chdir_scripts_root() +
+        'until test -f venv/.created; do sleep 1; done;' +
+        '. venv/bin/activate;'
+    )
 }
 
 function random(seed) {

--- a/plasmoid/contents/ui/utils.js
+++ b/plasmoid/contents/ui/utils.js
@@ -14,6 +14,19 @@ function chdir_scripts_root() {
     return 'cd "'+get_scripts_root()+'";'
 }
 
+function create_venv() {
+    return (
+        chdir_scripts_root() +
+        'test -d venv || python3 -m venv venv;' +
+        '. venv/bin/activate;' +
+        'pip install -r requirements.txt;'
+    )
+}
+
+function activate_venv() {
+    return chdir_scripts_root() + '. venv/bin/activate;'
+}
+
 function random(seed) {
     var x = Math.sin(seed*1000) * 10000;
     return x - Math.floor(x);

--- a/plasmoid/contents/ui/utils.js
+++ b/plasmoid/contents/ui/utils.js
@@ -19,6 +19,7 @@ function create_venv() {
         chdir_scripts_root() +
         'test -d venv || python3 -m venv venv;' +
         '. venv/bin/activate;' +
+        'until curl -f -LI https://pypi.org/simple; do sleep 1; done;' +
         'pip install -r requirements.txt;' +
         'touch venv/.created;' +
         'echo "venv_created"'


### PR DESCRIPTION
Okay, had to redo the PR since I noticed I was targetting the wrong branch. This should remove the need to install Python dependencies separately as the plasmoid will now create a venv and install dependencies into it.

To prevent some edge cases with regards to not being able to download the dependencies, it will wait till it can connect to pypi. Theoretically, the logic to ensure the venv is properly created could be even more robust than this (like what if pip install itself fails?), but this is probably good enough. I have tested it to work on my Gentoo machine.

Fixes #20.